### PR TITLE
Gracefully handle errors in `queryVernac` on older versions of coq

### DIFF
--- a/src/coq_serapy/coq_agent.py
+++ b/src/coq_serapy/coq_agent.py
@@ -301,7 +301,10 @@ class CoqAgent:
         return len(self.proof_context.fg_goals)
 
     def check_term(self, term: str) -> str:
-        return self.backend.queryVernac(f"Check {term}.")[0]
+        result = self.backend.queryVernac(f"Check {term}.")
+        if len(result) == 0:
+            raise ValueError(f"Can't check {term}")
+        return result[0]
     def locate_ident(self, ident: str) -> str:
         return "\n".join(self.backend.queryVernac(f"Locate {ident}."))
     def interrupt(self) -> None:

--- a/src/coq_serapy/serapi_backend.py
+++ b/src/coq_serapy/serapi_backend.py
@@ -184,7 +184,7 @@ class CoqSeraPyInstance(CoqBackend, threading.Thread):
         if self.coq_minor_version() <= 12:
             # we need to call "_get_completed" even if the response is bad
             # so that the next command can be processed correctly
-            def handle_bad_response():
+            def handle_bad_response(_: Any):
                 # Search is a special case. when we do a search, we stil need
                 # to get the completed message, even if the search fails
                 if "Search" in vernac:


### PR DESCRIPTION
On older versions of coq, when there is an error, serapi will send an `(Answer {int} (Objlist ...))` message before a completed message. We are throwing a `BadResponse` error when that happens, but are not consuming the following completed message. This leads to errors the next time we try to run a queryVernac. This change fixes the issue by making sure to consume the completed message before throwing a `BadResponse` error.